### PR TITLE
hotupgrade cleared env variables cleared

### DIFF
--- a/src/ddb.erl
+++ b/src/ddb.erl
@@ -92,18 +92,24 @@
 -spec credentials(string(), string(), string()) -> 'ok'.
 
 credentials(AccessKeyId, SecretAccessKey, SessionToken) ->
-    true = ets:insert('iam', {'accesskeyid', AccessKeyId}),
-    true = ets:insert('iam', {'secretaccesskey', SecretAccessKey}),
-    true = ets:insert('iam', {'sessiontoken', SessionToken}).
+    case ets:info('ddb') of
+        undefined ->    
+            ets:new('ddb', [named_table, public]);
+        _ ->
+            ok
+    end,
+    true = ets:insert('ddb', {'accesskeyid', AccessKeyId}),
+    true = ets:insert('ddb', {'secretaccesskey', SecretAccessKey}),
+    true = ets:insert('ddb', {'sessiontoken', SessionToken}).
 
 %%% Retrieve stored credentials.
 
 -spec credentials() -> {'ok', string(), string(), string()}.
 
 credentials() ->
-    [{'accesskeyid', AccessKeyId}] = ets:lookup('iam', 'accesskeyid'),
-    [{'secretaccesskey', SecretAccessKey}] = ets:lookup('iam', 'secretaccesskey'),
-    [{'sessiontoken', SessionToken}] = ets:lookup('iam', 'sessiontoken'),
+    [{'accesskeyid', AccessKeyId}] = ets:lookup('ddb', 'accesskeyid'),
+    [{'secretaccesskey', SecretAccessKey}] = ets:lookup('ddb', 'secretaccesskey'),
+    [{'sessiontoken', SessionToken}] = ets:lookup('ddb', 'sessiontoken'),
     {'ok', AccessKeyId, SecretAccessKey, SessionToken}.
 
 %%% Create a key type, either hash or hash and range.

--- a/src/ddb.erl
+++ b/src/ddb.erl
@@ -92,18 +92,18 @@
 -spec credentials(string(), string(), string()) -> 'ok'.
 
 credentials(AccessKeyId, SecretAccessKey, SessionToken) ->
-    'ok' = application:set_env('ddb', 'accesskeyid', AccessKeyId),
-    'ok' = application:set_env('ddb', 'secretaccesskey', SecretAccessKey),
-    'ok' = application:set_env('ddb', 'sessiontoken', SessionToken).
+    true = ets:insert('iam', {'accesskeyid', AccessKeyId}),
+    true = ets:insert('iam', {'secretaccesskey', SecretAccessKey}),
+    true = ets:insert('iam', {'sessiontoken', SessionToken}).
 
 %%% Retrieve stored credentials.
 
 -spec credentials() -> {'ok', string(), string(), string()}.
 
 credentials() ->
-    {'ok', AccessKeyId} = application:get_env('ddb', 'accesskeyid'),
-    {'ok', SecretAccessKey} = application:get_env('ddb', 'secretaccesskey'),
-    {'ok', SessionToken} = application:get_env('ddb', 'sessiontoken'),
+    [{'accesskeyid', AccessKeyId}] = ets:lookup('iam', 'accesskeyid'),
+    [{'secretaccesskey', SecretAccessKey}] = ets:lookup('iam', 'secretaccesskey'),
+    [{'sessiontoken', SessionToken}] = ets:lookup('iam', 'sessiontoken'),
     {'ok', AccessKeyId, SecretAccessKey, SessionToken}.
 
 %%% Create a key type, either hash or hash and range.

--- a/src/ddb_aws.erl
+++ b/src/ddb_aws.erl
@@ -71,6 +71,9 @@ retry(F, Max, N, H)
 			    %% This is expected in some use cases, so just trace at info level
 			    ok = lager:info("Got client error (~s) ~p, aborting...", [Code, Body]),
 			    {'error', H(Body)};
+			<<"com.amazon.coral.service#UnrecognizedClientException">> ->
+				ok = lager:warning("Got client error (~s) ~p, expired token...", [Code, Body]),
+			    {'error', 'expired_token'};
 			_ ->
 			    ok = lager:error("Got client error (~s) ~p, aborting...", [Code, Body]),
 			    {'error', H(Body)}

--- a/src/ddb_iam.erl
+++ b/src/ddb_iam.erl
@@ -43,7 +43,7 @@
 
 -spec credentials(string(), string()) -> 'ok'.
 
-ccredentials(AccessKeyId, SecretAccessKey) ->
+credentials(AccessKeyId, SecretAccessKey) ->
     case ets:info('iam') of
         undefined ->    
             ets:new('iam', [named_table, public]);

--- a/src/ddb_iam.erl
+++ b/src/ddb_iam.erl
@@ -44,14 +44,21 @@
 -spec credentials(string(), string()) -> 'ok'.
 
 credentials(AccessKeyId, SecretAccessKey) ->
-    'ok' = application:set_env('iam', 'accesskeyid', AccessKeyId),
-    'ok' = application:set_env('iam', 'secretaccesskey', SecretAccessKey).
+    case ets:info('iam') of
+        undefined ->    
+            ets:new('iam', [named_table, public]);
+        _ ->
+            ok
+    end,
+    ets:insert('iam', {'accesskeyid', AccessKeyId}),
+    ets:insert('iam', {'secretaccesskey', SecretAccessKey}),
+    'ok'.
 
 -spec credentials() -> {'ok', string(), string()}.
 
 credentials() ->
-    {'ok', AccessKeyId} = application:get_env('iam', 'accesskeyid'),
-    {'ok', SecretAccessKey} = application:get_env('iam', 'secretaccesskey'),
+    [{'ok', AccessKeyId}] = ets:lookup('iam', 'accesskeyid'),
+    [{'ok', SecretAccessKey}] = ets:lookup('iam', 'secretaccesskey'),
     {'ok', AccessKeyId, SecretAccessKey}.
 
 -spec token(pos_integer()) -> {'ok', string(), string(), string()} |

--- a/src/ddb_iam.erl
+++ b/src/ddb_iam.erl
@@ -43,7 +43,7 @@
 
 -spec credentials(string(), string()) -> 'ok'.
 
-credentials(AccessKeyId, SecretAccessKey) ->
+ccredentials(AccessKeyId, SecretAccessKey) ->
     case ets:info('iam') of
         undefined ->    
             ets:new('iam', [named_table, public]);
@@ -57,8 +57,8 @@ credentials(AccessKeyId, SecretAccessKey) ->
 -spec credentials() -> {'ok', string(), string()}.
 
 credentials() ->
-    [{'ok', AccessKeyId}] = ets:lookup('iam', 'accesskeyid'),
-    [{'ok', SecretAccessKey}] = ets:lookup('iam', 'secretaccesskey'),
+    [{'accesskeyid', AccessKeyId}] = ets:lookup('iam', 'accesskeyid'),
+    [{'secretaccesskey', SecretAccessKey}] = ets:lookup('iam', 'secretaccesskey'),
     {'ok', AccessKeyId, SecretAccessKey}.
 
 -spec token(pos_integer()) -> {'ok', string(), string(), string()} |


### PR DESCRIPTION
I keep credentials in ets other than env, because  they were cleared once i made an upgrade to my application.

Maybe i have upgraded in a wrong way, but keeping it in ets really solved my problem.